### PR TITLE
feat, test(utils): add email password and match field validators

### DIFF
--- a/src/app/infrastructure/utils/constants.ts
+++ b/src/app/infrastructure/utils/constants.ts
@@ -1,0 +1,12 @@
+interface Constants {
+  readonly DIGIT_REGEX: RegExp;
+  readonly EMAIL_REGEX: RegExp;
+  readonly SYMBOL_REGEX: RegExp;
+}
+
+export const CONSTANTS: Constants = {
+  DIGIT_REGEX: /[0-9]/,
+  EMAIL_REGEX:
+    /^[a-z0-9!#$%&'*+\/=?^_\`{|}~.-]+@[a-z0-9]([a-z0-9-])+(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/i,
+  SYMBOL_REGEX: /[-+_!@#$%^&*,.?]/,
+};

--- a/src/app/infrastructure/utils/validators/email-validator.spec.ts
+++ b/src/app/infrastructure/utils/validators/email-validator.spec.ts
@@ -1,0 +1,49 @@
+import { FormControl } from '@angular/forms';
+
+import { EmailValidator } from './email-validator';
+
+describe('[Unit] EmailValidator', () => {
+  describe('validEmail() Required', () => {
+    const emailValidator = EmailValidator.validEmail(true);
+    const emailControl = new FormControl('');
+
+    it(`should return null if value matches RegEx`, () => {
+      emailControl.setValue('test@test.com');
+      expect(emailValidator(emailControl)).toEqual(null);
+    });
+
+    it(`should return { isRequired: 'Email is required.' } when value is an empty string`, () => {
+      emailControl.setValue('');
+      const expectedValue = { isRequired: 'Email is required.' };
+      expect(emailValidator(emailControl)).toEqual(expectedValue);
+    });
+
+    it(`should return { invalidEmail: 'Please enter a valid email.' } when value does not match RegEx`, () => {
+      emailControl.setValue('test@');
+      const expectedValue = { invalidEmail: 'Please enter a valid email.' };
+      expect(emailValidator(emailControl)).toEqual(expectedValue);
+    });
+
+    it(`should return { invalidEmail: 'Please enter a valid email.' } when value is too short`, () => {
+      emailControl.setValue('t@t');
+      const expectedValue = { invalidEmail: 'Please enter a valid email.' };
+      expect(emailValidator(emailControl)).toEqual(expectedValue);
+    });
+
+    it(`should return { invalidEmail: 'Please enter a valid email.' } when domain is too short`, () => {
+      emailControl.setValue('test@t.com');
+      const expectedValue = { invalidEmail: 'Please enter a valid email.' };
+      expect(emailValidator(emailControl)).toEqual(expectedValue);
+    });
+  });
+
+  describe('validEmail() Not Required', () => {
+    const emailValidator = EmailValidator.validEmail(false);
+    const emailControl = new FormControl('');
+
+    it(`should return null when value is an empty string`, () => {
+      emailControl.setValue('');
+      expect(emailValidator(emailControl)).toEqual(null);
+    });
+  });
+});

--- a/src/app/infrastructure/utils/validators/email-validator.ts
+++ b/src/app/infrastructure/utils/validators/email-validator.ts
@@ -1,0 +1,18 @@
+import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+
+import { CONSTANTS } from '../constants';
+
+export class EmailValidator {
+  static validEmail(isRequired?: boolean): ValidatorFn {
+    return (control: AbstractControl): ValidationErrors | null => {
+      if (!control.value) {
+        return isRequired ? { isRequired: 'Email is required.' } : null;
+      }
+      if (!CONSTANTS.EMAIL_REGEX.test(control.value)) {
+        return { invalidEmail: 'Please enter a valid email.' };
+      }
+
+      return null;
+    };
+  }
+}

--- a/src/app/infrastructure/utils/validators/match-field-validator.spec.ts
+++ b/src/app/infrastructure/utils/validators/match-field-validator.spec.ts
@@ -1,0 +1,104 @@
+import { FormControl, FormGroup } from '@angular/forms';
+
+import { MatchFieldValidator } from './match-field-validator';
+
+describe('[Unit] MatchFieldValidator', () => {
+  describe('validFieldMatch() default field name', () => {
+    const matchFieldValidator = MatchFieldValidator.validFieldMatch(
+      'controlName',
+      'confirmControlName',
+    );
+    const form = new FormGroup({
+      controlName: new FormControl(''),
+      confirmControlName: new FormControl(''),
+    });
+    const controlName = form.get('controlName');
+    const confirmControlName = form.get('confirmControlName');
+
+    it(`should set control error as { confirmFieldRequired: 'Confirm Password is required.' } when value is an empty string`, () => {
+      controlName?.setValue('');
+      confirmControlName?.setValue('');
+      matchFieldValidator(form);
+      const expectedValue = {
+        confirmFieldRequired: 'Confirm Password is required.',
+      };
+      expect(confirmControlName?.errors).toEqual(expectedValue);
+    });
+
+    it(`should set control error as { fieldsMismatched: 'Password fields do not match.' } when values do not match`, () => {
+      controlName?.setValue('password123!');
+      confirmControlName?.setValue('password123');
+      matchFieldValidator(form);
+      const expectedValue = {
+        fieldsMismatched: 'Password fields do not match.',
+      };
+      expect(confirmControlName?.errors).toEqual(expectedValue);
+    });
+
+    it(`should set control error as null when values match`, () => {
+      controlName?.setValue('password123!');
+      confirmControlName?.setValue('password123!');
+      matchFieldValidator(form);
+      expect(controlName?.errors).toEqual(null);
+      expect(confirmControlName?.errors).toEqual(null);
+    });
+
+    it(`should set control error as null when control matches confirm after not matching`, () => {
+      controlName?.setValue('password123!');
+      confirmControlName?.setValue('password123!');
+      matchFieldValidator(form);
+      controlName?.setValue('password123');
+      matchFieldValidator(form);
+      controlName?.setValue('password123!');
+      matchFieldValidator(form);
+      expect(controlName?.errors).toEqual(null);
+      expect(confirmControlName?.errors).toEqual(null);
+    });
+
+    it(`should set control error as null when confirm matches control after not matching`, () => {
+      controlName?.setValue('password123!');
+      confirmControlName?.setValue('password123!');
+      matchFieldValidator(form);
+      controlName?.setValue('password123');
+      matchFieldValidator(form);
+      confirmControlName?.setValue('password123');
+      matchFieldValidator(form);
+      expect(controlName?.errors).toEqual(null);
+      expect(confirmControlName?.errors).toEqual(null);
+    });
+  });
+
+  describe(`validFieldMatch('Email') parameter field name`, () => {
+    const matchFieldValidator = MatchFieldValidator.validFieldMatch(
+      'controlName',
+      'confirmControlName',
+      'Email',
+    );
+    const form = new FormGroup({
+      controlName: new FormControl(''),
+      confirmControlName: new FormControl(''),
+    });
+    const controlName = form.get('controlName');
+    const confirmControlName = form.get('confirmControlName');
+
+    it(`should set control error as { confirmFieldRequired: 'Confirm Email is required.' } when value is an empty string`, () => {
+      controlName?.setValue('');
+      confirmControlName?.setValue('');
+      matchFieldValidator(form);
+      const expectedValue = {
+        confirmFieldRequired: 'Confirm Email is required.',
+      };
+      expect(confirmControlName?.errors).toEqual(expectedValue);
+    });
+
+    it(`should set control error as { fieldsMismatched: 'Email fields do not match.' } when values do not match`, () => {
+      controlName?.setValue('password123!');
+      confirmControlName?.setValue('test@test.co');
+      matchFieldValidator(form);
+      const expectedValue = {
+        fieldsMismatched: 'Email fields do not match.',
+      };
+      expect(confirmControlName?.errors).toEqual(expectedValue);
+    });
+  });
+});

--- a/src/app/infrastructure/utils/validators/match-field-validator.ts
+++ b/src/app/infrastructure/utils/validators/match-field-validator.ts
@@ -1,0 +1,35 @@
+import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+
+export class MatchFieldValidator {
+  static validFieldMatch(
+    controlName: string,
+    confirmControlName: string,
+    fieldName: string = 'Password',
+  ): ValidatorFn {
+    return (control: AbstractControl): ValidationErrors | null => {
+      const controlValue: unknown | null = control.get(controlName)?.value;
+      const confirmControlValue: unknown | null =
+        control.get(confirmControlName)?.value;
+
+      if (!confirmControlValue) {
+        control.get(confirmControlName)?.setErrors({
+          confirmFieldRequired: `Confirm ${fieldName} is required.`,
+        });
+      }
+
+      if (controlValue !== confirmControlValue) {
+        control
+          .get(confirmControlName)
+          ?.setErrors({
+            fieldsMismatched: `${fieldName} fields do not match.`,
+          });
+      }
+
+      if (controlValue && controlValue === confirmControlValue) {
+        control.get(confirmControlName)?.setErrors(null);
+      }
+
+      return null;
+    };
+  }
+}

--- a/src/app/infrastructure/utils/validators/password-validator.spec.ts
+++ b/src/app/infrastructure/utils/validators/password-validator.spec.ts
@@ -1,0 +1,59 @@
+import { FormControl } from '@angular/forms';
+
+import { PasswordValidator } from './password-validator';
+
+describe('[Unit] PasswordValidator', () => {
+  describe('validPassword() Required', () => {
+    const passwordValidator = PasswordValidator.validPassword(true);
+    const passwordControl = new FormControl('');
+
+    it(`should return null if value matches RegEx`, () => {
+      passwordControl.setValue('passwordTest1!');
+      expect(passwordValidator(passwordControl)).toEqual(null);
+    });
+
+    it(`should return { invalidPassword: 'Password is required.' } when value is an empty string`, () => {
+      passwordControl.setValue('');
+      const expectedValue = { invalidPassword: 'Password is required.' };
+      expect(passwordValidator(passwordControl)).toEqual(expectedValue);
+    });
+
+    it(`should return { invalidPassword: 'Password is too short.' } when value is too short`, () => {
+      passwordControl.setValue('test');
+      const expectedValue = { invalidPassword: 'Password is too short.' };
+      expect(passwordValidator(passwordControl)).toEqual(expectedValue);
+    });
+
+    it(`should return { invalidPassword: 'Password requires at least one special character.' } when missing special characters`, () => {
+      passwordControl.setValue('passwordTest1');
+      const expectedValue = {
+        invalidPassword: 'Password requires at least one special character.',
+      };
+      expect(passwordValidator(passwordControl)).toEqual(expectedValue);
+    });
+
+    it(`should return { invalidPassword: 'Password requires at least one numeric character.' } when missing numeric characters`, () => {
+      passwordControl.setValue('passwordTest!');
+      const expectedValue = {
+        invalidPassword: 'Password requires at least one numeric character.',
+      };
+      expect(passwordValidator(passwordControl)).toEqual(expectedValue);
+    });
+  });
+
+  describe('validPassword() Not Required', () => {
+    it(`should return null when value is an empty string`, () => {
+      const passwordValidator = PasswordValidator.validPassword(false);
+      const passwordControl = new FormControl('');
+      passwordControl.setValue('');
+      expect(passwordValidator(passwordControl)).toEqual(null);
+    });
+
+    it(`should return null when value is an empty string`, () => {
+      const passwordValidator = PasswordValidator.validPassword();
+      const passwordControl = new FormControl('');
+      passwordControl.setValue('');
+      expect(passwordValidator(passwordControl)).toEqual(null);
+    });
+  });
+});

--- a/src/app/infrastructure/utils/validators/password-validator.ts
+++ b/src/app/infrastructure/utils/validators/password-validator.ts
@@ -1,0 +1,28 @@
+import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+
+import { CONSTANTS } from '../constants';
+
+export class PasswordValidator {
+  static validPassword(isRequired: boolean = false): ValidatorFn {
+    return (control: AbstractControl): ValidationErrors | null => {
+      if (!control.value) {
+        return isRequired ? { invalidPassword: `Password is required.` } : null;
+      }
+      if (control.value.length < 8) {
+        return { invalidPassword: `Password is too short.` };
+      }
+      if (!CONSTANTS.SYMBOL_REGEX.test(control.value)) {
+        return {
+          invalidPassword: `Password requires at least one special character.`,
+        };
+      }
+      if (!CONSTANTS.DIGIT_REGEX.test(control.value)) {
+        return {
+          invalidPassword: `Password requires at least one numeric character.`,
+        };
+      }
+
+      return null;
+    };
+  }
+}

--- a/src/app/infrastructure/utils/validators/required-validator.spec.ts
+++ b/src/app/infrastructure/utils/validators/required-validator.spec.ts
@@ -1,9 +1,9 @@
 import { FormControl } from '@angular/forms';
 
-import { RequiredValidation } from './required-validation';
+import { RequiredValidator } from './required-validator';
 
-describe('[Unit] RequiredValidation required()', () => {
-  const isRequiredValidator = RequiredValidation.required();
+describe('[Unit] RequiredValidator required()', () => {
+  const isRequiredValidator = RequiredValidator.required();
   const defaultPlaceholder: string = 'This field';
   const testControl = new FormControl('');
 
@@ -26,9 +26,9 @@ describe('[Unit] RequiredValidation required()', () => {
   });
 });
 
-describe(`[Unit] RequiredValidation required('Custom Placeholder')`, () => {
+describe(`[Unit] RequiredValidator required('Custom Placeholder')`, () => {
   const customPlaceholder: string = 'Custom Placeholder';
-  const isRequiredValidator = RequiredValidation.required(customPlaceholder);
+  const isRequiredValidator = RequiredValidator.required(customPlaceholder);
   const testControl = new FormControl('');
 
   it(`should return { 'isRequired': 'Custom Placeholder is required.' } when value is an empty string`, () => {

--- a/src/app/infrastructure/utils/validators/required-validator.ts
+++ b/src/app/infrastructure/utils/validators/required-validator.ts
@@ -1,6 +1,6 @@
 import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
 
-export class RequiredValidation {
+export class RequiredValidator {
   /**
    * Returns an error if the passed in control has no value.
    */


### PR DESCRIPTION
# Changes

- [x] Add my commonly used form validators: EmailValidator, PasswordValidator, MatchFieldValidator, with tests.

Closes #15.