### PR TITLE
feat, refactor, test(infrastructure): add `buildRequestPayload()` to `FormService`

### DIFF
--- a/src/app/infrastructure/core/services/form.service.spec.ts
+++ b/src/app/infrastructure/core/services/form.service.spec.ts
@@ -1,0 +1,54 @@
+import { FormControl, FormGroup } from '@angular/forms';
+
+import { FormService } from './form.service';
+import { LoginRequest } from '../../models/auth';
+
+describe('[Unit] FormService', () => {
+  describe('formService', () => {
+    const formService = new FormService();
+    it('should be created', () => {
+      expect(formService).toBeTruthy();
+    });
+  });
+
+  describe('buildRequestPayload()', () => {
+    const formService = new FormService();
+    it(`should return a populated request object with values from matching form values`, () => {
+      const requestPayload = new LoginRequest({ email: 'test@test.com' });
+      const expectedValue = new LoginRequest({ email: 'test@test.com' });
+      const form = new FormGroup({});
+      form.addControl('email', new FormControl('test@test.com'));
+      form.addControl('password', new FormControl('password'));
+      expectedValue.email = 'test@test.com';
+      expectedValue.password = 'password';
+      expect(formService.buildRequestPayload(form, requestPayload)).toEqual(
+        expectedValue,
+      );
+    });
+
+    it(`should return a partially populated object with values from partially matching form values`, () => {
+      const payload = new LoginRequest();
+      const expectedValue = new LoginRequest();
+      const form = new FormGroup({});
+      form.addControl('email', new FormControl('test@test.com'));
+      form.addControl('test', new FormControl('test'));
+      expectedValue.email = 'test@test.com';
+      expectedValue.password = '';
+      expect(formService.buildRequestPayload(form, payload)).toEqual(
+        expectedValue,
+      );
+    });
+
+    it(`should return an initialized request object when no matching form values are found`, () => {
+      const payload = new LoginRequest();
+      const expectedValue = new LoginRequest();
+      const form = new FormGroup({});
+      form.addControl('test', new FormControl('test'));
+      expectedValue.email = '';
+      expectedValue.password = '';
+      expect(formService.buildRequestPayload(form, payload)).toEqual(
+        expectedValue,
+      );
+    });
+  });
+});

--- a/src/app/infrastructure/core/services/form.service.ts
+++ b/src/app/infrastructure/core/services/form.service.ts
@@ -1,29 +1,24 @@
 import { Injectable } from '@angular/core';
+import { FormGroup } from '@angular/forms';
 
 @Injectable({
   providedIn: 'root',
 })
 export class FormService {
-  constructor() {}
-
-  public serializeObj(object: object): string {
-    let component: string;
-    let serializedObject: string = '';
-
-    for (const property in object) {
-      if (object.hasOwnProperty(property)) {
-        component = `${property}=${encodeURIComponent(object[property])}&`;
-        serializedObject = serializedObject + component;
+  /**
+   * Build a request payload from the matching `FormGroup` values.
+   * Does not handle conditional logic.
+   */
+  public buildRequestPayload<T>(form: FormGroup, requestPayload: T): T {
+    for (const property in requestPayload) {
+      if (
+        requestPayload.hasOwnProperty(property) &&
+        form.controls[property]?.value
+      ) {
+        requestPayload[property] = form.controls[property].value;
       }
     }
 
-    return (serializedObject = serializedObject.substring(
-      0,
-      serializedObject.length - 1,
-    ));
-  }
-
-  public serializeString(string: string): string {
-    return encodeURIComponent(string);
+    return requestPayload;
   }
 }

--- a/src/app/infrastructure/models/auth.ts
+++ b/src/app/infrastructure/models/auth.ts
@@ -1,0 +1,15 @@
+export interface ILoginRequest {
+  email: string;
+  password: string;
+}
+
+export class LoginRequest implements ILoginRequest {
+  email: string = '';
+  password: string = '';
+
+  constructor(configOverride?: Partial<ILoginRequest>) {
+    if (configOverride) {
+      Object.assign(this, configOverride);
+    }
+  }
+}


### PR DESCRIPTION
# Changes

- [x] Add a `buildRequestPayload()` method to the `FormService` that helps map form values to the provided class object.
- [x] Clean up obsolete methods in `FormService`.

Closes #45.