### PR TITLE
docs(README): update Codecov badge links to specific branch results

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # AngularBaseApp
 
-| Branch      | Status                                                                                                                        | Coverage                                                                                                                                      |
-| ----------- | ----------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| development | ![development](https://github.com/Karvel/angular-base-app/workflows/Build,%20Test,%20and%20Lint/badge.svg?branch=development) | [![codecov](https://codecov.io/gh/Karvel/angular-base-app/branch/development/graph/badge.svg)](https://codecov.io/gh/Karvel/angular-base-app) |
-| main        | ![main](https://github.com/Karvel/angular-base-app/workflows/Build,%20Test,%20and%20Lint/badge.svg?branch=main)               | [![codecov](https://codecov.io/gh/Karvel/angular-base-app/branch/main/graph/badge.svg)](https://codecov.io/gh/Karvel/angular-base-app)        |
+| Branch      | Status                                                                                                                        | Coverage                                                                                                                                                             |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| development | ![development](https://github.com/Karvel/angular-base-app/workflows/Build,%20Test,%20and%20Lint/badge.svg?branch=development) | [![codecov](https://codecov.io/gh/Karvel/angular-base-app/branch/development/graph/badge.svg)](https://app.codecov.io/gh/Karvel/angular-base-app/branch/development) |
+| main        | ![main](https://github.com/Karvel/angular-base-app/workflows/Build,%20Test,%20and%20Lint/badge.svg?branch=main)               | [![codecov](https://codecov.io/gh/Karvel/angular-base-app/branch/main/graph/badge.svg)](https://app.codecov.io/gh/Karvel/angular-base-app/branch/main)               |
 
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 6.1.3 and has been updated to version 12.1.0.
 


### PR DESCRIPTION
# Changes

- [x] Link the Codecov badges to the results for the specific branches.

Closes #54.